### PR TITLE
Fix: Update router to handle invalid paths via query parameters for custom 404 page.

### DIFF
--- a/js/router.js
+++ b/js/router.js
@@ -1,22 +1,34 @@
 import { home, authentication, chooseSide, goodSide, badSide, pageNotFound } from './app.js';
 
- // Create routing for pages
- const routes = [
-     { path: '/', page: home },
-     { path: '/authentication', page: authentication },
-     { path: '/choose-side', page: chooseSide },
-     { path: '/good-side', page: goodSide },
-     { path: '/bad-side', page: badSide },
- ];
+// Create routing for pages
+const routes = [
+    { path: '/', page: home },
+    { path: '/authentication', page: authentication },
+    { path: '/choose-side', page: chooseSide },
+    { path: '/good-side', page: goodSide },
+    { path: '/bad-side', page: badSide },
+];
 
- // Function to find route and render a page
- export function renderPage(path) {
-     // Find the correct route given the path
-     const route = routes.find(r => r.path === path);
+// Function to find route and render a page
+export function renderPage() {
+    // Get the path from the query parameter (for redirects) or fallback to window.location.pathname
+    const urlParams = new URLSearchParams(window.location.search);
+    const currentPath = urlParams.get('path') || window.location.pathname;
 
-     if (route) {
-         route.page();
-     } else {
-         pageNotFound(); // Render 404 if page is not found 
-     }
- }
+    // Find the correct route given the path
+    const route = routes.find(r => r.path === currentPath);
+
+    if (route) {
+        route.page(); // Render the matched route
+    } else {
+        pageNotFound(); // Render 404 if page is not found
+    }
+}
+
+// Call renderPage on initial load
+renderPage();
+
+// Listen for popstate (back/forward navigation)
+window.addEventListener('popstate', () => {
+    renderPage();
+});


### PR DESCRIPTION
- Modified renderPage function in router.js to check for 'path' query parameters passed during redirects from 404.html.
- This change ensures that when GitHub Pages redirects to index.html, the SPA will correctly read the invalid path and display the custom 404 page.
- Routes are now matched using the path from the query parameter or window.location.pathname, preventing the app from defaulting to the home page.